### PR TITLE
Use GetServices instead of direct access

### DIFF
--- a/Module.lua
+++ b/Module.lua
@@ -1,4 +1,4 @@
-local Player = game.Players.LocalPlayer
+local Player = game:GetService("Players").LocalPlayer
 local Mouse = Player:GetMouse()
 
 local TextService = game:GetService("TextService")


### PR DESCRIPTION
Since this library is so nice, I decided to help you further ;-)

This PR fixes issues with games like Jailbreak, that change the name of the Players service.