### PR TITLE
Added UI protection.

### DIFF
--- a/Module.lua
+++ b/Module.lua
@@ -727,7 +727,15 @@ function Material.Load(Config)
 
 	local NewInstance = Objects.new("ScreenGui")
 	NewInstance.Name = Title
-	NewInstance.Parent = TargetParent
+
+    if syn and syn.protect_gui then
+        syn.protect_gui(NewInstance)
+        NewInstance.Parent = TargetParent
+    elseif (get_hidden_gui) then
+        NewInstance.Parent = get_hidden_gui()
+    else
+        NewInstance.Parent = TargetParent
+    end
 
 	MainGUI = NewInstance
 


### PR DESCRIPTION
Saw a v3rmillion thread (reference: https://v3rmillion.net/showthread.php?tid=1107200) talking about games detecting UI libraries via FindFirstChild so I thought I'd add simple protection for Synapse and ProtoSmasher users.

NOTE: I haven't tested this on ProtoSmasher so it might have bugs?